### PR TITLE
FIX: `recognize_image` and `recognize_url` can not accept timeout greater than 25

### DIFF
--- a/lib/scnnr/client.rb
+++ b/lib/scnnr/client.rb
@@ -17,18 +17,28 @@ module Scnnr
 
     def recognize_image(image, options = {})
       options = merge_options(options)
+      timeout = options[:timeout];
+      # Don't break async execution if timeout not given
+      if timeout > 0
+        options.delete(timeout)
+      end
       uri = construct_uri('recognitions', options)
-      # TODO: Use PollingManager to be accepted timeout > 25
       response = post_connection(uri, options).send_stream(image)
-      handle_response(response, options)
+      recognition = handle_response(response, options)
+      timeout > 0 ? fetch(recognition.id, options.merge(polling: true, timeout: timeout)) : recognition
     end
 
     def recognize_url(url, options = {})
       options = merge_options(options)
+      timeout = options[:timeout];
+      # Don't break async execution if timeout not given
+      if timeout > 0
+        options.delete(timeout)
+      end
       uri = construct_uri('remote/recognitions', options)
-      # TODO: Use PollingManager to be accepted timeout > 25
       response = post_connection(uri, options).send_json({ url: url })
-      handle_response(response, options)
+      recognition = handle_response(response, options)
+      timeout > 0 ? fetch(recognition.id, options.merge(polling: true, timeout: timeout)) : recognition
     end
 
     def fetch(recognition_id, options = {})


### PR DESCRIPTION
Any requests with timeout are now handled via Pollingmanager. If timeout == 0 or nil then everything is still executed asynchronously so as to not break existing code.