### PR TITLE
FIX: `recognize_image` and `recognize_url` can not accept timeout greater than 25

### DIFF
--- a/lib/scnnr/client.rb
+++ b/lib/scnnr/client.rb
@@ -18,21 +18,21 @@ module Scnnr
     def recognize(endpoint, func, options = {})
       options = merge_options(options)
       timeout = options[:timeout]
-      use_polling = timeout > 25;
+      use_polling = timeout > 25
       options[:timeout] = 0 if use_polling
       uri = construct_uri(endpoint, options)
-      response = func.(uri, options)
+      response = func.call(uri, options)
       recognition = handle_response(response, options)
       use_polling ? fetch(recognition.id, options.merge(polling: true, timeout: timeout)) : recognition
     end
 
     def recognize_image(image, options = {})
-      f = -> uri, opt { post_connection(uri, opt).send_stream(image) }
+      f = -> (uri, opt){ post_connection(uri, opt).send_stream(image) }
       recognize('recognitions', f, options)
     end
 
     def recognize_url(url, options = {})
-      f = -> uri, opt { post_connection(uri, opt).send_json({ url: url }) }
+      f = -> (uri, opt){ post_connection(uri, opt).send_json({ url: url }) }
       recognize('remote/recognitions', f, options)
     end
 

--- a/lib/scnnr/client.rb
+++ b/lib/scnnr/client.rb
@@ -27,12 +27,12 @@ module Scnnr
     end
 
     def recognize_image(image, options = {})
-      f = -> (uri, opt){ post_connection(uri, opt).send_stream(image) }
+      f = ->(uri, opt) { post_connection(uri, opt).send_stream(image) }
       recognize('recognitions', f, options)
     end
 
     def recognize_url(url, options = {})
-      f = -> (uri, opt){ post_connection(uri, opt).send_json({ url: url }) }
+      f = ->(uri, opt) { post_connection(uri, opt).send_json({ url: url }) }
       recognize('remote/recognitions', f, options)
     end
 

--- a/lib/scnnr/client.rb
+++ b/lib/scnnr/client.rb
@@ -17,18 +17,28 @@ module Scnnr
 
     def recognize_image(image, options = {})
       options = merge_options(options)
+      timeout = options[:timeout];
+      # Don't break async execution if timeout not given
+      if timeout > 0
+        options.delete(timeout)
+      end
       uri = construct_uri('recognitions', options)
-      # TODO: Use PollingManager to be accepted timeout > 25
       response = post_connection(uri, options).send_stream(image)
-      handle_response(response, options)
+      recognition = handle_response(response, options)
+      timeout > 0 ? fetch(recognition.id, options.merge(polling: true, timeout: timeout)) : recognition
     end
 
     def recognize_url(url, options = {})
       options = merge_options(options)
+      timeout = options[:timeout];
+      # Don't break async execution if timeout not given
+      if timeout > 0
+        options.delete(timeout)
+      end
       uri = construct_uri('remote/recognitions', options)
-      # TODO: Use PollingManager to be accepted timeout > 25
       response = post_connection(uri, options).send_json({ url: url })
-      handle_response(response, options)
+      recognition = handle_response(response, options)
+      timeout > 0 ? fetch(recognition.id, options.merge(polling: true, timeout: timeout)) : recognition
     end
 
     def fetch(recognition_id, options = {})

--- a/lib/scnnr/client.rb
+++ b/lib/scnnr/client.rb
@@ -23,7 +23,7 @@ module Scnnr
       uri = construct_uri('recognitions', options)
       response = post_connection(uri, options).send_stream(image)
       recognition = handle_response(response, options)
-      timeout > 0 ? fetch(recognition.id, options.merge(polling: true, timeout: timeout)) : recognition
+      timeout.positive? ? fetch(recognition.id, options.merge(polling: true, timeout: timeout)) : recognition
     end
 
     def recognize_url(url, options = {})
@@ -34,7 +34,7 @@ module Scnnr
       uri = construct_uri('remote/recognitions', options)
       response = post_connection(uri, options).send_json({ url: url })
       recognition = handle_response(response, options)
-      timeout > 0 ? fetch(recognition.id, options.merge(polling: true, timeout: timeout)) : recognition
+      timeout.positive? ? fetch(recognition.id, options.merge(polling: true, timeout: timeout)) : recognition
     end
 
     def fetch(recognition_id, options = {})

--- a/lib/scnnr/client.rb
+++ b/lib/scnnr/client.rb
@@ -17,11 +17,9 @@ module Scnnr
 
     def recognize_image(image, options = {})
       options = merge_options(options)
-      timeout = options[:timeout];
+      timeout = options[:timeout]
       # Don't break async execution if timeout not given
-      if timeout > 0
-        options.delete(timeout)
-      end
+      options.delete(timeout) if timeout.positive?
       uri = construct_uri('recognitions', options)
       response = post_connection(uri, options).send_stream(image)
       recognition = handle_response(response, options)
@@ -30,11 +28,9 @@ module Scnnr
 
     def recognize_url(url, options = {})
       options = merge_options(options)
-      timeout = options[:timeout];
+      timeout = options[:timeout]
       # Don't break async execution if timeout not given
-      if timeout > 0
-        options.delete(timeout)
-      end
+      options.delete(timeout) if timeout.positive?
       uri = construct_uri('remote/recognitions', options)
       response = post_connection(uri, options).send_json({ url: url })
       recognition = handle_response(response, options)


### PR DESCRIPTION
Any requests with timeout are now handled via Pollingmanager. If timeout == 0 or nil then everything is still executed asynchronously so as to not break existing code.