### PR TITLE
Use polling manager to allow long timeouts when recognising images

### DIFF
--- a/lib/scnnr/polling_manager.rb
+++ b/lib/scnnr/polling_manager.rb
@@ -6,6 +6,19 @@ module Scnnr
 
     attr_accessor :timeout
 
+    def self.start(client, options, &block)
+      timeout = options.delete(:timeout)
+      used_timeout = [timeout, MAX_TIMEOUT].min
+      extra_timeout = timeout - used_timeout
+
+      recognition = block.call(options.merge(timeout: used_timeout))
+      if recognition.queued? && extra_timeout.positive?
+        new(extra_timeout).polling(client, recognition.id, options)
+      else
+        recognition
+      end
+    end
+
     def initialize(timeout)
       case timeout
       when Integer, Float::INFINITY then @timeout = timeout
@@ -14,16 +27,14 @@ module Scnnr
       end
     end
 
-    def remain_timeout?
-      self.timeout.positive?
-    end
-
     def polling(client, recognition_id, options = {})
       loop do
         timeout = [self.timeout, MAX_TIMEOUT].min
         self.timeout -= timeout
         recognition = client.fetch(recognition_id, options.merge(timeout: timeout, polling: false))
-        break recognition if recognition.finished? || !self.remain_timeout?
+
+        break recognition unless recognition.queued?
+        raise TimeoutError.new('recognition timed out', recognition) unless self.timeout.positive?
       end
     end
   end

--- a/lib/scnnr/response.rb
+++ b/lib/scnnr/response.rb
@@ -4,10 +4,9 @@ module Scnnr
   class Response
     SUPPORTED_CONTENT_TYPE = 'application/jp.cubki.scnnr.v1+json'
 
-    def initialize(response, async)
+    def initialize(response)
       raise UnexpectedError, response if response.content_type != SUPPORTED_CONTENT_TYPE
       @response = response
-      @async = async
     end
 
     def body
@@ -16,10 +15,6 @@ module Scnnr
 
     def parsed_body
       @parsed_body ||= JSON.parse(self.body)
-    end
-
-    def async?
-      @async == true
     end
 
     def build_recognition
@@ -35,7 +30,6 @@ module Scnnr
     private
 
     def handle_recognition(recognition)
-      raise TimeoutError.new('recognition timed out', recognition) if recognition.queued? && async?
       return recognition unless recognition.error?
 
       case recognition.error['type']

--- a/spec/scnnr/client_spec.rb
+++ b/spec/scnnr/client_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Scnnr::Client do
 
       context 'when the first request finishes' do
         before do
-          expect(mock_response).to receive(:build_recognition) { finished_recognition }
+          allow(mock_response).to receive(:build_recognition) { finished_recognition }
         end
 
         it 'immediately returns the recognition' do
@@ -61,26 +61,26 @@ RSpec.describe Scnnr::Client do
 
       context 'when the second attempt finishes' do
         before do
-          expect(mock_response).to receive(:build_recognition) { queued_recognition }
-          expect(client).to receive(:fetch).with(
-            queued_recognition.id, hash_including(polling: true, timeout: timeout - api_max_timeout)
-          ).and_return(finished_recognition)
+          allow(mock_response).to receive(:build_recognition) { queued_recognition }
         end
 
         it 'returns the finished recognition' do
+          expect(client).to receive(:fetch).with(
+            queued_recognition.id, hash_including(polling: true, timeout: timeout - api_max_timeout)
+          ).and_return(finished_recognition)
           expect(subject).to eq finished_recognition
         end
       end
 
       context 'when the timeout is exceeded' do
         before do
-          expect(mock_response).to receive(:build_recognition) { queued_recognition }
-          expect(client).to receive(:fetch).with(
-            queued_recognition.id, hash_including(polling: true, timeout: timeout - api_max_timeout)
-          ).and_return(queued_recognition)
+          allow(mock_response).to receive(:build_recognition) { queued_recognition }
         end
 
         it 'returns the queued recognition' do
+          expect(client).to receive(:fetch).with(
+            queued_recognition.id, hash_including(polling: true, timeout: timeout - api_max_timeout)
+          ).and_return(queued_recognition)
           expect(subject).to eq queued_recognition
         end
       end
@@ -96,9 +96,9 @@ RSpec.describe Scnnr::Client do
     let(:expected_recognition) { Scnnr::Recognition.new }
 
     before do
-      expect(Scnnr::Connection).to receive(:new).with(uri, :post, api_key, logger) { mock_connection }
-      expect(mock_connection).to receive(:send_stream).with(image) { mock_origin_response }
-      expect(Scnnr::Response).to receive(:new).with(mock_origin_response, boolean) { mock_response }
+      allow(Scnnr::Connection).to receive(:new).with(uri, :post, api_key, logger) { mock_connection }
+      allow(mock_connection).to receive(:send_stream).with(image) { mock_origin_response }
+      allow(Scnnr::Response).to receive(:new).with(mock_origin_response, boolean) { mock_response }
     end
 
     it do
@@ -118,9 +118,9 @@ RSpec.describe Scnnr::Client do
     let(:expected_recognition) { Scnnr::Recognition.new }
 
     before do
-      expect(Scnnr::Connection).to receive(:new).with(uri, :post, api_key, logger) { mock_connection }
-      expect(mock_connection).to receive(:send_json).with({ url: url }) { mock_origin_response }
-      expect(Scnnr::Response).to receive(:new).with(mock_origin_response, boolean) { mock_response }
+      allow(Scnnr::Connection).to receive(:new).with(uri, :post, api_key, logger) { mock_connection }
+      allow(mock_connection).to receive(:send_json).with({ url: url }) { mock_origin_response }
+      allow(Scnnr::Response).to receive(:new).with(mock_origin_response, boolean) { mock_response }
     end
 
     it do

--- a/spec/scnnr/client_spec.rb
+++ b/spec/scnnr/client_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Scnnr::Client do
       context 'when the second attempt finishes' do
         before do
           expect(mock_response).to receive(:build_recognition) { queued_recognition }
-          expect(client).to receive(:fetch).with(queued_recognition.id, hash_including(timeout: timeout - api_max_timeout)) { finished_recognition }
+          expect(client).to receive(:fetch).with(queued_recognition.id, hash_including(polling: true, timeout: timeout - api_max_timeout)) { finished_recognition }
         end
 
         it 'returns the finished recognition' do
@@ -73,7 +73,7 @@ RSpec.describe Scnnr::Client do
       context 'when the timeout is exceeded' do
         before do
           expect(mock_response).to receive(:build_recognition) { queued_recognition }
-          expect(client).to receive(:fetch).with(queued_recognition.id, hash_including(timeout: timeout - api_max_timeout)) { queued_recognition }
+          expect(client).to receive(:fetch).with(queued_recognition.id, hash_including(polling: true, timeout: timeout - api_max_timeout)) { queued_recognition }
         end
 
         it 'returns the queued recognition' do

--- a/spec/scnnr/client_spec.rb
+++ b/spec/scnnr/client_spec.rb
@@ -62,7 +62,9 @@ RSpec.describe Scnnr::Client do
       context 'when the second attempt finishes' do
         before do
           expect(mock_response).to receive(:build_recognition) { queued_recognition }
-          expect(client).to receive(:fetch).with(queued_recognition.id, hash_including(polling: true, timeout: timeout - api_max_timeout)) { finished_recognition }
+          expect(client).to receive(:fetch).with(
+            queued_recognition.id, hash_including(polling: true, timeout: timeout - api_max_timeout)
+          ).and_return(finished_recognition)
         end
 
         it 'returns the finished recognition' do
@@ -73,7 +75,9 @@ RSpec.describe Scnnr::Client do
       context 'when the timeout is exceeded' do
         before do
           expect(mock_response).to receive(:build_recognition) { queued_recognition }
-          expect(client).to receive(:fetch).with(queued_recognition.id, hash_including(polling: true, timeout: timeout - api_max_timeout)) { queued_recognition }
+          expect(client).to receive(:fetch).with(
+            queued_recognition.id, hash_including(polling: true, timeout: timeout - api_max_timeout)
+          ).and_return(queued_recognition)
         end
 
         it 'returns the queued recognition' do

--- a/spec/scnnr/polling_manager_spec.rb
+++ b/spec/scnnr/polling_manager_spec.rb
@@ -5,19 +5,57 @@ require 'spec_helper'
 RSpec.describe Scnnr::PollingManager do
   let(:manager) { described_class.new(timeout) }
 
-  describe '#remain_timeout?' do
-    subject { manager.remain_timeout? }
+  describe '.start' do
+    subject(:result) { described_class.start(client, options, &block) }
 
-    context 'when timeout is 0' do
-      let(:timeout) { 0 }
+    let(:timeout) { Scnnr::PollingManager::MAX_TIMEOUT * 3 }
+    let(:client) { instance_double(Scnnr::Client) }
+    let(:options) { { api_key: 'test', timeout: timeout } }
+    let(:block) { proc { finished_recognition } }
 
-      it { is_expected.to be false }
+    let(:queued_recognition) { Scnnr::Recognition.new('state' => 'queued') }
+    let(:finished_recognition) { Scnnr::Recognition.new('state' => 'finished') }
+
+    it 'passes the max timeout and other options to the block' do
+      expect(block).to receive(:call).with({
+        api_key: 'test', timeout: Scnnr::PollingManager::MAX_TIMEOUT
+      }).and_return(finished_recognition)
+
+      result
     end
 
-    context 'when timeout is greater than 0' do
-      let(:timeout) { rand(1..25) }
+    context 'when the block returns a finished recognition' do
+      let(:block) { proc { finished_recognition } }
 
-      it { is_expected.to be true }
+      it 'immediately returns the recognition' do
+        expect(client).not_to receive(:fetch)
+        expect(subject).to eq finished_recognition
+      end
+    end
+
+    context 'when the first fetch attempt finishes' do
+      let(:block) { proc { queued_recognition } }
+
+      it 'returns the finished recognition' do
+        expect(client).to receive(:fetch).with(
+          queued_recognition.id, hash_including(polling: false, timeout: Scnnr::PollingManager::MAX_TIMEOUT)
+        ).and_return(finished_recognition)
+        expect(subject).to eq finished_recognition
+      end
+    end
+
+    context 'when the timeout is exceeded' do
+      let(:block) { proc { queued_recognition } }
+
+      it 'times out with the queued recognition' do
+        expect(client).to receive(:fetch).with(
+          queued_recognition.id, hash_including(polling: false, timeout: Scnnr::PollingManager::MAX_TIMEOUT)
+        ).exactly(2).times.and_return(queued_recognition)
+
+        expect { subject }.to raise_error(Scnnr::TimeoutError) do |e|
+          expect(e.recognition).to eq queued_recognition
+        end
+      end
     end
   end
 
@@ -63,17 +101,33 @@ RSpec.describe Scnnr::PollingManager do
             .once { recognition })
           expect { subject }.to change { manager.timeout }
             .from(timeout).to([timeout - Scnnr::PollingManager::MAX_TIMEOUT, 0].max)
+          expect(subject).to eq recognition
+        end
+      end
+
+      context 'and finished recognition fails' do
+        let(:recognition) { Scnnr::Recognition.new('state' => 'error') }
+
+        it do
+          expect(client).to(receive(:fetch).with(recognition_id, hash_including(timeout: anything, polling: false))
+            .once { recognition })
+          expect { subject }.to change { manager.timeout }
+            .from(timeout).to([timeout - Scnnr::PollingManager::MAX_TIMEOUT, 0].max)
+          expect(subject).to eq recognition
         end
       end
 
       context 'and not finished recognition returns' do
-        let(:recognition) { Scnnr::Recognition.new }
+        let(:recognition) { Scnnr::Recognition.new('state' => 'queued') }
         let(:times) { (Float(timeout) / Scnnr::PollingManager::MAX_TIMEOUT).ceil }
 
         it do
           expect(client).to(receive(:fetch).with(recognition_id, hash_including(timeout: anything, polling: false))
             .exactly(times).times { recognition })
-          expect { subject }.to change { manager.timeout }.from(timeout).to(0)
+
+          expect { subject }.to raise_error(Scnnr::TimeoutError) do |e|
+            expect(e.recognition).to eq recognition
+          end
         end
       end
     end

--- a/spec/scnnr/response_spec.rb
+++ b/spec/scnnr/response_spec.rb
@@ -10,9 +10,8 @@ RSpec.describe Scnnr::Response do
       allow(origin_response).to receive(:body) { body }
       allow(origin_response).to receive(:content_type) { content_type }
     end
-    let(:response) { described_class.new(origin_response, async) }
+    let(:response) { described_class.new(origin_response) }
     let(:origin_response) { response_class.new(nil, nil, nil) }
-    let(:async) { false }
     let(:parsed_body) { JSON.parse(body) }
     let(:content_type) { Scnnr::Response::SUPPORTED_CONTENT_TYPE }
 
@@ -28,18 +27,6 @@ RSpec.describe Scnnr::Response do
           is_expected.to be_queued
           expect(subject.id).to eq parsed_body['id']
           expect(subject.objects).to be_empty
-        end
-
-        context 'with async request' do
-          let(:async) { true }
-
-          it do
-            expect { subject }.to raise_error(Scnnr::TimeoutError) do |e|
-              expect(e.recognition).to be_a Scnnr::Recognition
-              expect(e.recognition.id).to eq parsed_body['id']
-              expect(e.recognition.objects.map(&:to_h)).to match_array parsed_body['objects']
-            end
-          end
         end
       end
 


### PR DESCRIPTION
This is affected by #9, so I think this doesn't fully solve the problem because a `TimeoutError` will still be thrown after the initial request. I have a fix for that issue too, but thought I would show you this first.

This takes advantage of the existing `fetch` method, since `PollingManager` is already tightly coupled to that.

Let me know what you think!