### PR TITLE
Support `target` parameter on `POST /v1/coordinates`

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Refer: [`POST /v1/coordinates`](https://api.scnnr.cubki.jp/v1/docs#tag/coordinat
 
 ```
 tastes = { casual: 0.7, girly: 0.3 }
-coordinate = client.coordinate('tops', ['グレー', 'パーカー'], tastes, target: 2)
+coordinate = client.coordinate('tops', ['グレー', 'パーカー'], tastes, target: 3)
 
 coordinate.to_h
 => {"items"=>

--- a/README.md
+++ b/README.md
@@ -4,17 +4,21 @@
 - [API Documentation](https://api.scnnr.cubki.jp/v1/docs)
 
 ## Installation
+
 ### Bundler
+
 ```
 gem 'scnnr'
 ```
 
 ### Manual
+
 ```
 gem install scnnr
 ```
 
 ## Configuration
+
 You can pass configuration options as a block to `Scnnr::Client.new`.
 
 ```
@@ -35,6 +39,8 @@ end
 
 Request image recognition by an image URL.
 
+Refer: [`POST /v1/remote/recognitions`](https://api.scnnr.cubki.jp/v1/docs#tag/remoterecognitions%2Fpaths%2F~1remote~1recognitions%2Fpost)
+
 ```
 url = 'https://example.com/dummy.jpg'
 recognition = client.recognize_url(url)
@@ -44,6 +50,8 @@ recognition = client.recognize_url(url, timeout: 10)
 ```
 
 Request image recognition by a binary image.
+
+Refer: [`POST /v1/recognitions`](https://api.scnnr.cubki.jp/v1/docs#tag/recognitions%2Fpaths%2F~1recognitions%2Fpost)
 
 ```
 img = File.open('dummy_image_file', 'rb')
@@ -127,6 +135,8 @@ If the timeout value is zero or `nil`, you will get `Recognition` instance whose
 
 Then you can fetch the recognition result using `Scnnr::Client#fetch`.
 
+Refer: [`GET /v1/recognitions/*`](https://api.scnnr.cubki.jp/v1/docs#tag/recognitions%2Fpaths%2F~1recognitions~1*%2Fget)
+
 ```
 recognition.queued?
 => true
@@ -143,8 +153,11 @@ recognition.finished?
 
 Request fashion coordinates generation.
 
+Refer: [`POST /v1/coordinates`](https://api.scnnr.cubki.jp/v1/docs#tag/coordinates%2Fpaths%2F~1coordinates%2Fpost)
+
 ```
-coordinate = client.coordinate('tops', ['グレー', 'パーカー'], casual: 0.7, girly: 0.3)
+tastes = { casual: 0.7, girly: 0.3 }
+coordinate = client.coordinate('tops', ['グレー', 'パーカー'], tastes, target: 2)
 
 coordinate.to_h
 => {"items"=>

--- a/lib/scnnr/client.rb
+++ b/lib/scnnr/client.rb
@@ -45,7 +45,7 @@ module Scnnr
 
     def coordinate(category, labels, taste = {}, options = {})
       options = merge_options options
-      uri = construct_uri('coordinates', %i[], options)
+      uri = construct_uri('coordinates', %i[target], options)
       payload = {
         item: { category: category, labels: labels },
         taste: TASTES.each_with_object({}) { |key, memo| memo[key] = taste[key] if taste[key] },

--- a/spec/scnnr/client_spec.rb
+++ b/spec/scnnr/client_spec.rb
@@ -104,21 +104,34 @@ RSpec.describe Scnnr::Client do
     let(:taste) { { casual: 0.3, girly: 0.7 } }
     let(:taste_with_unknown) { taste.merge(unknown: 0.4) }
     let(:options) { {} }
-    let(:uri) { URI.parse "#{expected_uri_base}/coordinates" }
-    let(:expected_payload) do
-      {
-        item: { category: category, labels: labels },
-        taste: taste,
-      }
-    end
-    let(:expected_coordinate) { nil }
 
-    it do
-      expect(Scnnr::Connection).to receive(:new).with(uri, :post, api_key, logger) { mock_connection }
-      expect(mock_connection).to receive(:send_json).with(expected_payload) { mock_origin_response }
-      expect(Scnnr::Response).to receive(:new).with(mock_origin_response) { mock_response }
-      expect(mock_response).to receive(:build_coordinate) { expected_coordinate }
-      expect(subject).to eq expected_coordinate
+    shared_examples_for('sending an expected request and a coordinate returns successfully') do
+      let(:uri) { URI.parse "#{expected_uri_base}/coordinates" }
+      let(:expected_payload) do
+        {
+          item: { category: category, labels: labels },
+          taste: taste,
+        }
+      end
+      let(:expected_coordinate) { nil }
+
+      it do
+        expect(Scnnr::Connection).to receive(:new).with(uri, :post, api_key, logger) { mock_connection }
+        expect(mock_connection).to receive(:send_json).with(expected_payload) { mock_origin_response }
+        expect(Scnnr::Response).to receive(:new).with(mock_origin_response) { mock_response }
+        expect(mock_response).to receive(:build_coordinate) { expected_coordinate }
+        expect(subject).to eq expected_coordinate
+      end
+    end
+
+    it_behaves_like 'sending an expected request and a coordinate returns successfully'
+
+    context 'when `target` option is passed' do
+      let(:options) { { target: 8 } }
+
+      it_behaves_like 'sending an expected request and a coordinate returns successfully' do
+        let(:uri) { URI.parse "#{expected_uri_base}/coordinates?target=8" }
+      end
     end
   end
 end


### PR DESCRIPTION
@danimal141 @iusztin  I added changes to support `target` parameter on `POST /v1/coordinates`.
Please check it!