### PR TITLE
Improve scnnr error handling

### DIFF
--- a/lib/scnnr/response.rb
+++ b/lib/scnnr/response.rb
@@ -36,7 +36,9 @@ module Scnnr
       case recognition.error['type']
       when 'unexpected-content', 'bad-request'
         raise RequestFailed, recognition.error
-      else raise RecognitionFailed, recognition
+      when 'download-timeout', 'invalid-image'
+        raise RecognitionFailed, recognition
+      else raise UnexpectedError, @response
       end
     end
 

--- a/spec/fixtures/download_timeout_error.json
+++ b/spec/fixtures/download_timeout_error.json
@@ -1,0 +1,1 @@
+{"error":{"detail":"Downloading the image has been timed out. Please retry with `force` parameter.","title":"Downloading timed out","type":"download-timeout"},"id":"20170829/ed4c674c-7970-4e9c-9b26-1b6076b36b49","objects":[],"state":"error"}

--- a/spec/fixtures/internal_server_error.json
+++ b/spec/fixtures/internal_server_error.json
@@ -1,0 +1,1 @@
+{"error":{"detail":"Some error details","title":"Internal Server Error","type":"internal-server-error"},"id":"20170829/ed4c674c-7970-4e9c-9b26-1b6076b36b49","objects":[],"state":"error"}

--- a/spec/scnnr/response_spec.rb
+++ b/spec/scnnr/response_spec.rb
@@ -96,13 +96,39 @@ RSpec.describe Scnnr::Response do
     end
 
     context 'when recognition state is error' do
-      let(:body) { fixture('unexpected_content_error.json').read }
+      context 'Unexpected Content Error' do
+        let(:body) { fixture('unexpected_content_error.json').read }
 
-      it do
-        expect { subject }.to raise_error(Scnnr::RequestFailed) do |e|
-          expect(e.type).to eq parsed_body['error']['type']
-          expect(e.title).to eq parsed_body['error']['title']
-          expect(e.detail).to eq parsed_body['error']['detail']
+        it do
+          expect { subject }.to raise_error(Scnnr::RequestFailed) do |e|
+            expect(e.type).to eq parsed_body['error']['type']
+            expect(e.title).to eq parsed_body['error']['title']
+            expect(e.detail).to eq parsed_body['error']['detail']
+          end
+        end
+      end
+
+      context 'Download Timeout Error' do
+        let(:body) { fixture('download_timeout_error.json').read }
+
+        it do
+          expect { subject }.to raise_error(Scnnr::RecognitionFailed) do |e|
+            expect(e.recognition).not_to be nil
+            expect(e.type).to eq parsed_body['error']['type']
+            expect(e.title).to eq parsed_body['error']['title']
+            expect(e.detail).to eq parsed_body['error']['detail']
+          end
+        end
+      end
+
+      context 'Internal Server Error' do
+        let(:body) { fixture('internal_server_error.json').read }
+
+        it do
+          expect { subject }.to raise_error(Scnnr::UnexpectedError) do |e|
+            expect(e.response).to eq origin_response
+            expect(e.message).to eq body
+          end
         end
       end
     end


### PR DESCRIPTION
I've added `internal-server-error`, `download-timeout` and `invalid-image` handling with specs for some of them. Taking `bad-request` as an example I didn't include spec for `invalid-image` since it raises the same error as `download-timeout`.

Please take a look!