### PR TITLE
Chore/release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2020-09-14
+### Added
+- Start supporting Ruby 2.7.
+- Provide image error details.
+- Raise `UnexpectedError` for unknown recognition error types.
+
+### Removed
+- Support for Ruby 2.3.
+
 ## [1.3.0] - 2019-08-30
 ### Added
 - Support a retrying feature on `Scnnr::Connection`.

--- a/lib/scnnr/version.rb
+++ b/lib/scnnr/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Scnnr
-  VERSION = '1.3.0'
+  VERSION = '2.0.0'
 end


### PR DESCRIPTION
@iusztin 
Prepared the release of the new version.
Link to draft release
https://github.com/NEWROPE/scnnr-ruby/releases/tag/untagged-7d3931b6d1959ddcbed0
Major update caused by https://github.com/NEWROPE/scnnr-ruby/pull/36#pullrequestreview-485492017
I want to confirm changelog and version choice - if it looks good I'll release it and after that rerun CI (I think it fails because of version change).

Please check 🙏 